### PR TITLE
Make reflection usages work more easily in Java 17+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>40.0.0</version>
+		<version>41.1.0</version>
 	</parent>
 
 	<!-- ../scijava-scripts/release-version.sh - -skip-version-check -->

--- a/src/main/java/de/embl/cba/bdp2/open/fileseries/FileInfosHelper.java
+++ b/src/main/java/de/embl/cba/bdp2/open/fileseries/FileInfosHelper.java
@@ -48,6 +48,8 @@ import java.util.stream.Collectors;
 
 public class FileInfosHelper
 {
+    static { org.scijava.launcher.ReflectionUnlocker.unlockAll(); }
+
     public static void setFileInfos5D( FileInfos fileInfos, String regExp, String[] channelSubset )
     {
         initFileInfos5D( fileInfos, regExp, channelSubset, Pattern.compile( regExp ) );

--- a/src/main/java/de/embl/cba/bdp2/utils/BdvImagePlusExport.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/BdvImagePlusExport.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/BdvRaiXYZCTExporter.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/BdvRaiXYZCTExporter.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/BdvToVoxelGridImageConverter.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/BdvToVoxelGridImageConverter.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/BdvUtils.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/BdvUtils.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/ColorUtils.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/ColorUtils.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/ConcatenatedTransformAnimator.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/ConcatenatedTransformAnimator.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/CopyUtils.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/CopyUtils.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/Corners.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/Corners.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/DoubleStatistics.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/DoubleStatistics.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/FileAndUrlUtils.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/FileAndUrlUtils.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/NeighborhoodAverageConverter.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/NeighborhoodAverageConverter.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/NeighborhoodNonZeroBoundariesConverter.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/NeighborhoodNonZeroBoundariesConverter.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/NeighborhoodViews.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/NeighborhoodViews.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/OSUtils.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/OSUtils.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/PathMapper.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/PathMapper.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/PixelValueStatistics.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/PixelValueStatistics.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/ProgressWriterBdv.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/ProgressWriterBdv.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/RectangleShape2.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/RectangleShape2.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/SwingUtils.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/SwingUtils.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/Transforms.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/Transforms.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/de/embl/cba/bdp2/utils/Utils.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/Utils.java
@@ -61,6 +61,7 @@ import net.imglib2.interpolation.randomaccess.ClampingNLinearInterpolatorFactory
 import net.imglib2.interpolation.randomaccess.NearestNeighborInterpolatorFactory;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.NativeType;
+import net.imglib2.type.Type;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
@@ -323,10 +324,10 @@ public class Utils {
 		}
 	}
 
-	public static int getBitDepth( RandomAccessibleInterval< ? > raiXYZCT )
+	public static < T extends Type< T > > int getBitDepth(RandomAccessibleInterval< T > raiXYZCT )
 	{
 		int bitDepth;
-		final Object typeFromInterval = Util.getTypeFromInterval( raiXYZCT );
+		final T typeFromInterval = raiXYZCT.getType();
 		if ( typeFromInterval instanceof UnsignedByteType )
 			bitDepth = 8;
 		else if ( typeFromInterval instanceof UnsignedShortType )
@@ -677,9 +678,9 @@ public class Utils {
     /*
         Use when extracting full image from RandomAccessibleInterval extracted from a Bdv Handle
     */
-    public static Img getCellImgFromInterval(RandomAccessibleInterval rai){
-       NativeType nativeType =  Util.getTypeFromInterval(rai);
-       Img imgTemp = ImgView.wrap(rai,new CellImgFactory<>(nativeType));
+    public static < T extends NativeType< T > > Img< T > getCellImgFromInterval(RandomAccessibleInterval< T > rai){
+       T nativeType =  rai.getType();
+       Img< T > imgTemp = ImgView.wrap(rai,new CellImgFactory<>(nativeType));
        return imgTemp;
     }
 

--- a/src/main/java/de/embl/cba/bdp2/utils/VolatileNeighborhoodAverageConverter.java
+++ b/src/main/java/de/embl/cba/bdp2/utils/VolatileNeighborhoodAverageConverter.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Various Java code for ImageJ
+ * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2024 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/run/RunImageJ.java
+++ b/src/test/java/run/RunImageJ.java
@@ -32,6 +32,12 @@ import net.imagej.ImageJ;
 
 public class RunImageJ
 {
+	// Note: To run this with Java 17+, you must modify the run configuration
+	// to include the JVM argument:
+	//
+	//    --add-opens=java.base/java.lang=ALL-UNNAMED
+	//
+	// Or else you will receive the dreaded "No _hooks field found in ij.IJ" error!
 	public static void main( String... args )
 	{
 		final ImageJ ij = new ImageJ();

--- a/src/test/java/test/open/TestOpenCZIWithBioFormats.java
+++ b/src/test/java/test/open/TestOpenCZIWithBioFormats.java
@@ -2,7 +2,7 @@
  * #%L
  * Fiji plugin for inspection and processing of big image data
  * %%
- * Copyright (C) 2018 - 2023 EMBL
+ * Copyright (C) 2018 - 2025 EMBL
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
This patch invokes SciJava's `ReflectionUnlocker` as appropriate, to reduce the need for passing `--add-opens` flags when running code within this project. With this change, only one flag should be required: `--add-opens=java.base/java.lang=ALL-UNNAMED`, which is the flag that gives permission to the `ReflectionUnlocker` to use reflection to do its thing. :laugh:

It also updates to the latest release of pom-scijava, as well as updating the copyright blurb year to 2025.